### PR TITLE
Implementing configurable fallbackLocale

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
 import once from 'lodash.once';
 
+export const defaults = {
+  fallbackLocale: 'en-US',
+};
+
 function filterDuplicates(arr) {
   return arr.filter((el, index, self) => self.indexOf(el) === index);
 }
@@ -40,7 +44,7 @@ function getUserLocalesInternal() {
     }
   }
 
-  languageList.push('en-US'); // Fallback
+  languageList.push(defaults.fallbackLocale); // Fallback
 
   return fixLowercaseProperties(filterDuplicates(languageList));
 }

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,6 +1,7 @@
 import getUserLocaleDefault, {
   getUserLocale,
   getUserLocales,
+  defaults,
 } from './index';
 
 const navigatorLanguageProperties = ['language', 'languages', 'userLanguage', 'browserLanguage', 'systemLanguage'];
@@ -94,6 +95,20 @@ describe('getUserLocale()', () => {
 
     expect(getUserLocale()).toEqual('en-US');
   });
+
+  it('returns overwritten default when no navigator properties are given', () => {
+    const navigator = {};
+    const fallbackLocale = 'en-GB';
+
+    const originalFallbackLocale = defaults.fallbackLocale;
+    defaults.fallbackLocale = fallbackLocale;
+
+    mockNavigator(navigator);
+
+    expect(getUserLocale()).toEqual(fallbackLocale);
+
+    defaults.fallbackLocale = originalFallbackLocale;
+  });
 });
 
 describe('getUserLocales()', () => {
@@ -171,5 +186,18 @@ describe('getUserLocales()', () => {
     mockNavigator(navigator);
 
     expect(getUserLocales()).toEqual(['en-US']);
+  });
+
+  it('returns overwritten default when no navigator properties are given', () => {
+    const navigator = {};
+    const fallbackLocale = 'en-GB';
+
+    const originalFallbackLocale = defaults.fallbackLocale;
+    defaults.fallbackLocale = fallbackLocale;
+
+    mockNavigator(navigator);
+
+    expect(getUserLocales()).toEqual([fallbackLocale]);
+    defaults.fallbackLocale = originalFallbackLocale;
   });
 });


### PR DESCRIPTION
Implementing a 'defaults' object which contains the fallbackLocale (en-US default still);

Populating languageList fallbackLocale from 'defaults' object
Exporting the 'defaults' object so it can be mutated programatically
Includes tests